### PR TITLE
Redirects from 2013 pages were broken and did not use 301 status

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ In order to compress the assets (CSS and JS) for a distribution (images are alre
 
 3. Run Grunt - `grunt` from the root of this code.
 
+## Notes.
+- Flight has been extended with some useful helper functions. You can find these in main/methods.php
+
 ## Licensing
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.

--- a/main/main.php
+++ b/main/main.php
@@ -13,10 +13,12 @@ class CoursesFrontEnd {
 	{
 		static::$pp = new ProgrammesPlant\API(XCRI_WEBSERVICE);
 
+/**
 		if (defined('CACHE_DIRECTORY') && is_dir(CACHE_DIRECTORY))
 		{
 		    static::$pp->with_cache('file')->directory(CACHE_DIRECTORY);
 		}
+**/
 
 		static::$pp->no_ssl_verification();
 	}
@@ -377,45 +379,49 @@ class CoursesFrontEnd {
 		}
 
 		// If we somehow hit a search url, fix it.
-		if($slug=='search'){
-			return Flight::redirect("{$level}/{$year}/search");
+		if($slug == 'search')
+		{
+			return Flight::redirect(Flight::url("{$level}/search"), 301);
 		}
 
 		// If we have an id, try a direct redirect
 		if($id !== null){
 			// Auto fix
-			$correct_url = Flight::url("{$level}/{$year}/{$id}/{$slug}", false);
-			return Flight::redirect($correct_url);
+			return Flight::redirect(Flight::url("{$level}/{$year}/{$id}/{$slug}"), 301);
 		}
 
 		// Else attempt a fix
 		$programmes = $this->get_programme_index($year, $level);
+
 		$correct_url = false;
+		$matches = 0;
 
 		// look through the list and see if we recoginise that slug from anyware
-		foreach($programmes as $programme){
-
-			//echo $programme->name;
-			if(strpos($programme->name, $slug) !== false || strpos($programme->slug, $slug) !== false){
-
-				// If correct url IS NOT false, it means we have two results and cannot auto fix reliably.
-				// Go to 404 in this case
-				if($correct_url){
-					$data = array('slug' => $slug, 'year'=> $year, 'level' => $level, 'error_msg' => "Multiple matches, unable to guess redirect.");
-					return Flight::notFound($data);
-				}
-			
-				// Correct URL	
-				$correct_url = Flight::url("{$level}/{$year}/{$programme->id}/{$programme->slug}", false);
-				//die($correct_url);
+		foreach($programmes as $programme)
+		{
+			if($programme->slug == $slug)
+			{
+				$correct_url = Flight::url("{$level}/{$year}/{$programme->id}/{$programme->slug}");
+			} 
+			elseif(strpos($programme->name, $slug) !== false || strpos($programme->slug, $slug) !== false)
+			{
+				$matches++;
 			}
 		}
-		// Only 1 matched result, send em on there wau
-		if($correct_url) return Flight::redirect($correct_url);
 
-		// Else 404, we cant help
-		$data = array('slug' => $slug, 'year'=> $year, 'level' => $level,'error_msg' => "No matches found, unable to guess redirect.");
-		return Flight::notFound($data);
+		if($correct_url) // If there is an exact match, 301 redirect to it.
+		{ 
+			return Flight::redirect($correct_url, 301);
+		} 
+		elseif($matches > 0) // If there are multiple, inexact matches 404 with suggestions.
+		{  
+			$data = array('slug' => $slug, 'year'=> $year, 'level' => $level, 'error_msg' => "Multiple matches, unable to guess redirect.");
+			return Flight::notFound($data);
+		} 
+		else // If there are no inexact matches, just 404.
+		{
+			return Flight::notFound();
+		}
 	}
 
 	// Quietly grab index


### PR DESCRIPTION
- Added 301 status to search and exact-match redirects
  - Ensured that the redirects use absolute URLs (they were being
    appended relatively)
  - Updated README.md to note that Flight has been extended
