### PR TITLE
UG/PG search-bar bug

### DIFF
--- a/main/main.php
+++ b/main/main.php
@@ -359,7 +359,7 @@ class CoursesFrontEnd {
 	public function ajax_search_data($level, $year)
 	{
 		// Cache json output for a minute or so (go faster!)
-		$output = Cache::get("courses-daedalus-search-json", function() use ($level, $year) {
+		$output = Cache::get("courses-daedalus-search-json-{$level}-{$year}", function() use ($level, $year) {
 
 			try
 			{


### PR DESCRIPTION
caches being created for the ajax search were being cached under the same name, which means ug and pg searches used the same cache. this fixes that
