### PR TITLE
switched back to the live url for ths kis widget

### DIFF
--- a/views/ug_tabs/enquiries.php
+++ b/views/ug_tabs/enquiries.php
@@ -166,6 +166,6 @@
 	</div>
 	<div class="span5">
 		<?php $ukprn = (isset($course->kis_institution_id) && $course->kis_institution_id != '') ? $course->kis_institution_id : $course->globals->ukprn; ?>
-		<iframe class="pull-right" id="unistats-widget-frame" title="Unistats KIS Widget" src="http://stg.unistats.eduserv.org.uk/Widget/<?php echo $ukprn ?>/<?php echo str_replace(array('/', '|', ':', '&', '.', '>', '+', '#', ';', '?', '@', '=', '!'), '_', $course->kiscourseid); ?>/vertical/small/en-GB" scrolling="no" style="overflow: hidden; border: 0px none transparent; width: 190px; height: 500px;"> </iframe>
+		<iframe class="pull-right" id="unistats-widget-frame" title="Unistats KIS Widget" src="http://widget.unistats.ac.uk/Widget/<?php echo $ukprn ?>/<?php echo str_replace(array('/', '|', ':', '&', '.', '>', '+', '#', ';', '?', '@', '=', '!'), '_', $course->kiscourseid); ?>/vertical/small/en-GB" scrolling="no" style="overflow: hidden; border: 0px none transparent; width: 190px; height: 500px;"> </iframe>
 	</div>
 </div>


### PR DESCRIPTION
this is a fix to get the live kis widget working.

I _think_ when unistats go live with the new widget this one will automatically switch, because presumably they will be using the same url. However we're going to have to keep an eye on this.
