### PR TITLE
Deliveries on inquiry page bug

### DIFF
--- a/views/pg_tabs/enquiries.php
+++ b/views/pg_tabs/enquiries.php
@@ -14,7 +14,7 @@
 	$awards = array();
 	$descriptions = array();
 
-	foreach($course->deliveries as $delivery){
+	foreach($course->deliveries as $key => $delivery){
 
 		$mode = $delivery->attendance_pattern;
 		$award = $delivery->award_name;


### PR DESCRIPTION
Fix #617
The $key variable was missing so the last deliver was always the one to display.
