### PR TITLE
ability to filter profiles by subject category

### DIFF
--- a/app/controllers/CoursesController.php
+++ b/app/controllers/CoursesController.php
@@ -939,10 +939,10 @@ class CoursesController {
 		return rtrim($award_list, ', ');
 	}
 
-	public function profiles($level = 'undergraduate'){
+	public function profiles($level = 'undergraduate', $search_string = ''){
 		try{
 			$profiles = static::$pp->make_request($level . '/profile');
-			$cats = static::$pp->get_subjectcategories($level);
+			$subject_categories = static::$pp->get_subjectcategories($level);
 		}catch(\Exception $e){
 			return Flight::notFound();
 		}
@@ -967,7 +967,9 @@ class CoursesController {
 			 	'level' => $level,
 			 	'level_code'=>$level_code,
 			 	'level_pretty'=>$level_pretty,
-			  	'categories' => $cats
+				'subject_categories' => $subject_categories,
+				'search_type' => 'subject_category',
+				'search_string' => $search_string
 		));
 	}
 

--- a/app/routes.php
+++ b/app/routes.php
@@ -88,7 +88,9 @@ Flight::route('/@level:undergrad|postgrad|ug|pg/@year:[0-9]+/@id:[0-9]+/@slug', 
 
 Flight::route('/profiles/', array($courses, 'profiles'));
 Flight::route('/profiles/@level:undergraduate|postgraduate/', array($courses, 'profiles'));
+Flight::route('/profiles/@level:undergraduate|postgraduate/subject/@search_string', array($courses, 'profiles'));
 Flight::route('/profiles/@level:undergraduate|postgraduate/@slug', array($courses, 'profile'));
+
 
 /**
  * Module page routes

--- a/app/views/profiles.php
+++ b/app/views/profiles.php
@@ -21,9 +21,21 @@
 			<div class="filter-select">
 				<select class="custom-select subject-search form-control" data-filter-col="__subjects">
 					<option value="">All subjects</option>
-					<?php foreach ($categories as $v){ ?>
-						<option value="<?php echo $v->name; ?>"><?php echo $v->name; ?></option>
-					<?php }?>
+					<?php
+
+					$subject_categories = (array) $subject_categories;
+					usort($subject_categories, function ($a, $b){
+						if ($a->name == $b->name) {
+							return 0;
+						}
+						return ($a->name < $b->name) ? -1 : 1;
+					});
+
+					foreach($subject_categories as $sc): ?>
+					<option <?php if(strcmp($search_type, 'subject_category')  == 0  && strcmp(urldecode(strtolower($search_string)), strtolower(slug_escape($sc->name))) == 0) echo 'selected'; ?>><?php echo $sc->name?></option>
+					<?php endforeach; ?>
+
+					?>
 				</select>
 			</div>
 	</div>


### PR DESCRIPTION
We can now have urls which only show profiles in the search results for a given subject category.
eg if you go to https://www.kent.ac.uk/courses/profiles/undergraduate/subject/arts you would see a pre-filtered version of https://www.kent.ac.uk/courses/profiles/undergraduate/ but only showing results for arts

- new route /profiles/{level}/subject/{subjectname}
- modified existing profiles controller
- added new filter match in view