### PR TITLE
Fix for a short period when PP has been cloned but not yet rolled over..

### DIFF
--- a/app/views/ug/search.php
+++ b/app/views/ug/search.php
@@ -26,7 +26,7 @@
 
 		<header class="content-header">
 			<?php \unikent\kent_theme\kentThemeHelper::breadcrumb(array("Courses"=>"/courses/", "Undergraduate" . ($year!=='current'? ' ' . $year : '')=>"")); ?>
-			<h1>Undergraduate courses - <?php echo $year !== 'current' ? $year : $years[0] ?> entry</h1>
+			<h1>Undergraduate courses - <?php echo $year !== 'current' ? $year : $years[1] ?> entry</h1>
 		</header>
 
 	<?php endif; ?>


### PR DESCRIPTION
..and 'current' gets confused as to what year it is

EXPLANATION:

SCENARIO:
We have cloned the 2018 UG prospectus to 2019, so the $years array contains:
[0] => '2019'
[1] => '2018'

However, 2019 is not yet set as the working year because we have not launched the 2019 prospectus yet.

On the search page, we are showing 2018 courses, and since 2018 is current, $year === 'current'

Therefore, the h1 looks for $year[0], which is 2019, so the 2018 courses search declares that these courses are for 2019... oops.

As a TEMPORARY fix, I have changed this to $year[1] - this will need to be reverted when the rollover occurs on 27 Feb. I tried various combinations of other branching to get the correct year output, but we are scuppered by our use of the word 'current' rather than a year in the variable, as this needs to work properly (as now) once there is only again one set of published courses.