### PR TITLE
Suppress output of module deliveries not for this year

### DIFF
--- a/app/views/modules/module.php
+++ b/app/views/modules/module.php
@@ -49,7 +49,7 @@
 						<tbody>
 							<?php
 							foreach ($module->deliveries as $delivery){
-								if (!empty($delivery->delivery_sessions)){
+								if (!empty($delivery->delivery_sessions) && in_array($module->year,$delivery->delivery_sessions)){
 									?>
 									<tr>
 										<td><span><?php echo $delivery->campus; ?><?php if ($delivery->module_version > 1 ){ ?><br>(version <?php echo $delivery->module_version; ?>)<?php } ?></span></td>


### PR DESCRIPTION
Change the display output for a module page to remove any rows for deliveries that are not happening this year.

This follows on from hiding years which are beyond the current year.

To see the problem, try:
https://www.kent.ac.uk/courses/modules/module/HA316

To see the fix in action, try:
https://www-test.kent.ac.uk/courses/modules/module/HA316