### PR TITLE
Feature/clearing link suppress

### DIFF
--- a/app/config.sample.php
+++ b/app/config.sample.php
@@ -1,11 +1,18 @@
 <?php
 
 const XCRI_WEBSERVICE = 'https://webtools.kent.ac.uk/programmes/api/';
-const API_URL = 'https://api.kent.ac.uk/api';
+const TEMPLATING_ENGINE = '/www/pantheon/latest/engine';
+const FAIL_ALERT_EMAIL = '';
+
+const WEBROOT = 'https://static.kent.ac.uk/pantheon/kent-theme-assets/';
+const HOME_URL = 'https://www.kent.ac.uk';
 const THEME_LIBS = '/path/to/kentTheme';
 
-const FAIL_ALERT_EMAIL = '';
 const LOCAL = true;
 const DEBUG = true;
 const CLEARING = false;
+const CLEARING_EMBARGO = false;
 const CACHE_DIRECTORY = '/tmp';
+const API_URL = 'https://api.kent.ac.uk/api';
+const DISABLE_CURL_PROXY = true;
+const SHOW_UG_PREVIOUS_YEAR_BANNER true;

--- a/app/views/partials/notices.php
+++ b/app/views/partials/notices.php
@@ -14,7 +14,7 @@
 			<div class="clearing-banner-container card-block">
 				<h2 class="col-lg-3 clearing-banner-title">CLEARING <?php echo $course->year;?></h2>
 				<?php if (defined('CLEARING_EMBARGO') && CLEARING_EMBARGO):?>
-					<div class="col-lg-8 clearing-banner-text">The Clearing vacancies list will be available from 06.30 on Thursday 16 August.</div>
+					<div class="col-lg-8 clearing-banner-text">The Clearing vacancies list will be available from 06.00 on Thursday 16 August.</div>
 				<?php else:?>
 					<div class="col-lg-5 clearing-banner-text">We may still have full-time vacancies available for this course.</div>
 					<a class="col-lg-3" href="https://evision.kent.ac.uk/ipp/ClearingVacancyList.htm"><button type="button" class="btn btn-primary clearing-banner-search-button">Search Vacancies</button></a>
@@ -29,7 +29,7 @@
 			<div class="clearing-banner-container card-block">
 				<h2 class="col-lg-3 clearing-banner-title">CLEARING <?php echo $previous_year;?></h2>
 				<?php if (defined('CLEARING_EMBARGO') && CLEARING_EMBARGO):?>
-					<div class="col-lg-8 clearing-banner-text">Planning to start this September? The Clearing vacancies list will be available from 06.30 on Thursday 16 August.</div>
+					<div class="col-lg-8 clearing-banner-text">Planning to start this September? The Clearing vacancies list will be available from 06.00 on Thursday 16 August.</div>
 				<?php else:?>
 					<div class="col-lg-8 clearing-banner-text">Planning to start this September? We may still have full-time vacancies available for this course. <a href="<?php echo "/courses/$level/$previous_year/$course->instance_id"; ?>">View 2018 course details.</a></div>
 				<?php endif; ?>

--- a/app/views/partials/notices.php
+++ b/app/views/partials/notices.php
@@ -12,9 +12,13 @@
 	<?php elseif ( isset($course) && $course->current_year > $course->year ): ?>
 		<div class="card card-backed-tertiary">
 			<div class="clearing-banner-container card-block">
-				<h2 class="col-lg-3 clearing-banner-title">CLEARING 2018</h2>
-				<div class="col-lg-5 clearing-banner-text">We may still have full-time vacancies available for this course.</div>
-				<a class="col-lg-3" href="https://evision.kent.ac.uk/ipp/ClearingVacancyList.htm"><button type="button" class="btn btn-primary clearing-banner-search-button">Search Vacancies</button></a>
+				<h2 class="col-lg-3 clearing-banner-title">CLEARING <?php echo $course->year;?></h2>
+				<?php if (defined('CLEARING_EMBARGO') && CLEARING_EMBARGO):?>
+					<div class="col-lg-8 clearing-banner-text">The Clearing vacancies list will be available from 06.30 on Thursday 16 August.</div>
+				<?php else:?>
+					<div class="col-lg-5 clearing-banner-text">We may still have full-time vacancies available for this course.</div>
+					<a class="col-lg-3" href="https://evision.kent.ac.uk/ipp/ClearingVacancyList.htm"><button type="button" class="btn btn-primary clearing-banner-search-button">Search Vacancies</button></a>
+				<?php endif; ?>
 			</div>
 		</div>
 	<?php elseif(isset($course) && $course->current_year == $course->year):
@@ -23,8 +27,12 @@
 		?>
 		<div class="card card-backed-tertiary">
 			<div class="clearing-banner-container card-block">
-				<h2 class="col-lg-3 clearing-banner-title">CLEARING 2018</h2>
-				<div class="col-lg-8 clearing-banner-text">Planning to start this September? We may still have full-time vacancies available for this course. <a href="<?php echo "/courses/$level/$previous_year/$course->instance_id"; ?>">View 2018 course details.</a> </div>
+				<h2 class="col-lg-3 clearing-banner-title">CLEARING <?php echo $previous_year;?></h2>
+				<?php if (defined('CLEARING_EMBARGO') && CLEARING_EMBARGO):?>
+					<div class="col-lg-8 clearing-banner-text">Planning to start this September? The Clearing vacancies list will be available from 06.30 on Thursday 16 August.</div>
+				<?php else:?>
+					<div class="col-lg-8 clearing-banner-text">Planning to start this September? We may still have full-time vacancies available for this course. <a href="<?php echo "/courses/$level/$previous_year/$course->instance_id"; ?>">View 2018 course details.</a></div>
+				<?php endif; ?>
 			</div>
 		</div>
 

--- a/app/views/ug/tabs/entry.php
+++ b/app/views/ug/tabs/entry.php
@@ -14,8 +14,11 @@
 		<p>
 			However during Clearing (after 4 July), our entry requirements change in real time to reflect the supply and demand of remaining course vacancies and so may be higher or lower than those published on UCAS as typical entry grades.
 		</p>
+		
 		<p>
+		<?php if(!(defined('CLEARING_EMBARGO') && CLEARING_EMBARGO)):?>
 			Our <a href="https://evision.kent.ac.uk/ipp/clearingvacancylist.htm">Clearing vacancy list</a> will be updated regularly as courses move in and out of Clearing, so please check regularly to see if we have any places available. You can submit an application via our online Clearing application form as soon as your full results are known.
+		<?php endif;?>
 			See our <a href="https://www.kent.ac.uk/clearing/index.html">Clearing website</a> for more details on how Clearing works at Kent.
 		</p>
 	<?php endif; ?>


### PR DESCRIPTION
During the period from just before the download of A Level results from UCAS (Friday before Clearing) and 06:00 on the Thursday of Clearing morning, we need to suppress links to the Clearing Vacancy List, and offer up alternative text to the user explaining that vacancies will be published after 06:00 on Thursday.

This change enables that, with a new config file constant, and a check for that constant in the notices partial.