### PR TITLE
Remove year from drop-down menu in Apply Now model for PG courses

### DIFF
--- a/app/views/pg/apply-modal.php
+++ b/app/views/pg/apply-modal.php
@@ -91,12 +91,12 @@ foreach($course->deliveries as $delivery){
 													}
 													if($has_fulltime){
 														?>
-														<option value="full-time" selected="selected">Full-time - <?php echo $course->year; ?></option>
+														<option value="full-time" selected="selected">Full-time</option>
 														<?php
 													}
 													if($has_parttime){
 														?>
-														<option value="part-time">Part-time - <?php echo $course->year; ?></option>
+														<option value="part-time">Part-time</option>
 														<?php
 													}
 													?>


### PR DESCRIPTION
for https://trello.com/c/jX1x8px3/1434-pg-change

Removes the year from the dropdown menu in the PG courses Apply Now model. 

Note there is a hidden form var with the year in it which seems to be used in the js to hide links, I've left that in there. It is not actually passed on to kentVision. The Apply button is just a link styled to look like a button and that does not have the year in it at all. 