### PR TITLE
WIP: Show module details as well as not-running message on resting modules.

### DIFF
--- a/app/views/modules/module.php
+++ b/app/views/modules/module.php
@@ -30,41 +30,45 @@
 		<h1><?php echo $module->title; ?>&nbsp;-&nbsp;<?php echo $module->sds_code; ?></h1>
 	</header>
 	<div class="content-body ">
-		<?php if(!empty($module->deliveries)){ ?>
 
 			<div class="content-container">
 				<div class="content-full">
 					<div class="panel panel-primary-tint mb-2 table-responsive">
-					<table class="table">
-						<thead>
-							<tr>
-								<th>Location</th>
-								<th>Term</th>
-								<th>Level</th>
-								<th>Credits <a class="credits-help" href="#" data-toggle="popover" data-trigger="focus" tabindex="0" role="button" data-content="ECTS credits are recognised throughout the EU and allow you to transfer credit easily from one university to another">(ECTS)</a></th>
-								<th><a class="convenor-help" href="#" data-toggle="popover" data-trigger="focus" tabindex="0" role="button" data-content="This is the convenor for the current academic session">Current Convenor</a></th>
-								<th><?php echo $module->year-1 . '-' . substr($module->year, 2);  ?></th>
-							</tr>
-						</thead>
-						<tbody>
-							<?php
-							foreach ($module->deliveries as $delivery){
-								if (!empty($delivery->delivery_sessions) && in_array($module->year,$delivery->delivery_sessions)){
-									?>
-									<tr>
-										<td><span><?php echo $delivery->campus; ?><?php if ($delivery->module_version > 1 ){ ?><br>(version <?php echo $delivery->module_version; ?>)<?php } ?></span></td>
-										<td><?php echo $delivery->term; ?><br><a href="<?php echo $delivery->delivery_url; ?>" title="View Timetable"><small>View Timetable</small></a></td>
-										<td><a href="#" data-toggle="popover" data-trigger="focus" tabindex="0" role="button" data-content="<?php echo $delivery->credit_level_desc; ?>" id="level-info"><?php echo $delivery->credit_level; ?></a></td>
-										<td><?php echo $delivery->credit_amount; ?></td>
-										<td><?php echo $delivery->convenor; ?></td>
-										<td class="text-center"><i class="kf-<?php echo in_array($module->year,$delivery->delivery_sessions)?'check':'close';?>"></i></td>
-									</tr>
-									<?php
+						<?php if(empty($module->deliveries)){ ?>
+									<p>Sorry, this module is not currently running in <?php echo $module->year-1 . '-' . substr($module->year, 2);  ?>.</p>
+						<?php }else{?>
+						<table class="table">
+							<thead>
+								<tr>
+									<th>Location</th>
+									<th>Term</th>
+									<th>Level</th>
+									<th>Credits <a class="credits-help" href="#" data-toggle="popover" data-trigger="focus" tabindex="0" role="button" data-content="ECTS credits are recognised throughout the EU and allow you to transfer credit easily from one university to another">(ECTS)</a></th>
+									<th><a class="convenor-help" href="#" data-toggle="popover" data-trigger="focus" tabindex="0" role="button" data-content="This is the convenor for the current academic session">Current Convenor</a></th>
+									<th><?php echo $module->year-1 . '-' . substr($module->year, 2);  ?></th>
+								</tr>
+							</thead>
+
+							<tbody>
+								<?php
+								foreach ($module->deliveries as $delivery){
+									if (!empty($delivery->delivery_sessions) && in_array($module->year,$delivery->delivery_sessions)){
+										?>
+										<tr>
+											<td><span><?php echo $delivery->campus; ?><?php if ($delivery->module_version > 1 ){ ?><br>(version <?php echo $delivery->module_version; ?>)<?php } ?></span></td>
+											<td><?php echo $delivery->term; ?><br><a href="<?php echo $delivery->delivery_url; ?>" title="View Timetable"><small>View Timetable</small></a></td>
+											<td><a href="#" data-toggle="popover" data-trigger="focus" tabindex="0" role="button" data-content="<?php echo $delivery->credit_level_desc; ?>" id="level-info"><?php echo $delivery->credit_level; ?></a></td>
+											<td><?php echo $delivery->credit_amount; ?></td>
+											<td><?php echo $delivery->convenor; ?></td>
+											<td class="text-center"><i class="kf-<?php echo in_array($module->year,$delivery->delivery_sessions)?'check':'close';?>"></i></td>
+										</tr>
+										<?php
+									}
 								}
-							}
-							?>
-						</tbody>
-					</table>
+								?>
+							</tbody>
+						</table>
+						<?php } ?>
 					</div>
 				</div>
 
@@ -174,11 +178,3 @@
 
 		</div>
 </div>
-
-	<?php } else { ?>
-		<div class="content-container pt-1">
-			<div class="content-full">
-				<p>Sorry, this module is not currently running.</p>
-			</div>
-		</div>
-	<?php } ?>

--- a/app/views/modules/tabs/reading.php
+++ b/app/views/modules/tabs/reading.php
@@ -5,6 +5,8 @@
 
 						<?php if(isset($module->reading_lists)): ?>
 							<?php foreach ($module->reading_lists as $campus => $url): ?>
-								<p><a href="<?php echo $url ?>">See the library reading list for this module (<?php echo ucfirst($campus); ?>)</a></p>
+								<?php if($url):?>
+									<p><a href="<?php echo $url ?>">See the library reading list for this module (<?php echo ucfirst($campus); ?>)</a></p>
+								<?php endif;?>
 							<?php endforeach; ?>
 						<?php endif; ?>


### PR DESCRIPTION
https://trello.com/c/QKNhtu5f/1477-module-not-running-modification

Currently a module not running in the current session just displays the module title and the message "Sorry, this module is not currently running", e.g. https://www.kent.ac.uk/courses/modules/module/art510

![currentunavailablemodule](https://user-images.githubusercontent.com/1048450/51166847-be689300-189c-11e9-8163-baaa1d58867e.png)

This pr displays the full modules details even if a module is not running, but replaces the delivery information block with the not running message:

![unavailablemodule](https://user-images.githubusercontent.com/1048450/51166831-b3adfe00-189c-11e9-9cd7-8d7687efa2c1.png)

vs running module:

![availablemodule](https://user-images.githubusercontent.com/1048450/51166865-ca545500-189c-11e9-9fd2-e89946aa69b1.png)

To test this checkout the branch and browse to a module which is not available this year (eg /courses/modules/module/art510 )


This pr also adds a check to only display links to reading lists if links to reading lists actually exist as currently a blank link (which results in a link to the current page) is shown for reading lists if no list exists (as for current api misconfiguration)

![no-reading-list](https://user-images.githubusercontent.com/1048450/51167131-93cb0a00-189d-11e9-9124-c5204bdc8188.png)
becomes
![no-reading-list](https://user-images.githubusercontent.com/1048450/51167119-8ca3fc00-189d-11e9-9d55-84151520282d.png)
