### PR TITLE
Use config const to toggle unistats widget - in prep for replacement …

### DIFF
--- a/app/config.sample.php
+++ b/app/config.sample.php
@@ -16,3 +16,6 @@ const CACHE_DIRECTORY = '/tmp';
 const API_URL = 'https://api.kent.ac.uk/api';
 const DISABLE_CURL_PROXY = true;
 const SHOW_UG_PREVIOUS_YEAR_BANNER true;
+
+// show KIS / Discover UNI widget
+const SHOW_UNISTATS_WIDGET = true;

--- a/app/views/ug/course.php
+++ b/app/views/ug/course.php
@@ -164,7 +164,7 @@ $course->pos_code = isset($course->deliveries[0]) ? $course->deliveries[0]->pos_
 <?php Flight::render("partials/profile-feature"); ?>
 	<div class="content-container">
 		<div class="content-full">
-			<?php if ($course->kiscourseid != '' && $course->programme_suspended != 'true'): ?>
+			<?php if ($course->kiscourseid != '' && $course->programme_suspended != 'true' && (SHOW_UNISTATS_WIDGET == true)): ?>
 				<section class="panel tertiary-tier highlighted no-border kiss-widget-section">
 					<div class="row">
 					<?php if ($has_fulltime){ ?>


### PR DESCRIPTION
…of widget

this adds a new config option of `` to control the output of the unistats widget on the undergraduate course information pages.

This is added so we we can turn it off on 11/09/19 while we make any arrangements we need to make for the new unistats widget which will be live from the 11th after 5pm.